### PR TITLE
fixed preloader link and styling

### DIFF
--- a/main.css
+++ b/main.css
@@ -21,9 +21,10 @@ body{
   line-height: 1.6;
 }
 
+/* preloader icon updated and black color removed  */
 #preloader{
-  background: black url(gifloader.gif) no-repeat center center;
-  background-size: 15%;
+  background:url('https://media.giphy.com/media/OcKLo9xfUxnEgKUw7i/giphy.gif') no-repeat center center;
+  background-size: 25%;
   height: 100vh;
   width:100%;
   position: fixed;


### PR DESCRIPTION
changed and fixed preloader link with a giphy preloader gif and changed its background size to make it look very clear earlie link was broken so it was not working.

have a look 
![image](https://user-images.githubusercontent.com/92878881/197218763-2c0e2aae-3cd2-469e-a209-c2340c9c48f8.png)

Please merge it to the main branch mam.
